### PR TITLE
fix double t_srs argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ shp/ch/lakes.shp: src/V200/VEC200_Commune.shp
 shp/ch/contours.shp: shp/ch/contours-unclipped.shp shp/ch/country.shp
 	mkdir -p $(dir $@)
 	mkdir -p tmp/
-	ogr2ogr $(if $(REPROJECT),-t_srs EPSG:4326,-t_srs EPSG:21781) tmp/contours.shp $<
+	ogr2ogr $(if $(REPROJECT),-t_srs 'EPSG:4326' -s_srs 'EPSG:21781') tmp/contours.shp $<
 	ogr2ogr -clipsrc shp/ch/country.shp $@ tmp/contours.shp
 	rm -f tmp/contours.*
 


### PR DESCRIPTION
On line 179 of the Makefile there were two -t_srs arguments. That looks wrong compared to the other changes made in https://github.com/interactivethings/swiss-maps/commit/38a7a87d4bc2e6c94167430833822a8205e6ab3f .

I have not tested this. This is just a change to make it look similar to the other entries.
