### PR TITLE
npm pkg fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/interactivethings/swiss-maps.git"
+    "url": "git+https://github.com/interactivethings/swiss-maps.git"
   },
   "scripts": {
     "preversion": "make",


### PR DESCRIPTION
> npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
> npm warn publish errors corrected:
> npm warn publish "repository.url" was normalized to "git+https://github.com/interactivethings/swiss-maps.git"
