### PR TITLE
Fix files pattern in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "files": [
     "README.md",
     "LICENSE",
-    "20*/"
+    "20*/*"
   ],
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Looks like npm (which we now use to publish, instead of yarn) treats the patterns in package.json `files` differently. With this patch, the tarball contains the correct files.